### PR TITLE
`volumechange` event not fired

### DIFF
--- a/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
+++ b/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
@@ -116,7 +116,7 @@
     function onPlayerReady( event ) {
 
       var onMuted = function() {
-        if ( player.isMuted() ) {
+        if ( self.muted ) {
           // force an initial play on the video, to remove autostart on initial seekTo.
           addYouTubeEvent( "play", onFirstPlay );
           if (!navigator.userAgent.match(/(iPad|iPhone|iPod|Android)/g)) {
@@ -141,7 +141,7 @@
 
       // Browsers using flash will have the pause() call take too long and cause some
       // sound to leak out. Muting before to prevent this.
-      player.mute();
+      self.muted = true;
 
       // ensure we are muted.
       onMuted();
@@ -203,7 +203,7 @@
 
       // Ensure video will now be unmuted when playing due to the mute on initial load.
       if( !impl.muted ) {
-        player.unMute();
+        self.muted = false;
       }
 
       impl.readyState = self.HAVE_METADATA;


### PR DESCRIPTION
Here is workaround for Apple mobiles to allow launch videos. The main issue is in that Apple disallow to adjust sound from code - developer can't use .muted property and will not receive `volumechange` event. So it was a reason why we're getting issue - there was infinite loop awaiting for sound muting.
This patch fixes it in my tests, and I can't invent reasons where it can break playing (maybe it's because I'm still not too familiar with project). So I'd appreciate for any thoughts about it.

Proofs: [Volume Control in JavaScript](https://developer.apple.com/library/safari/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html#//apple_ref/doc/uid/TP40009523-CH5-SW11), [Overcoming iOS HTML5 audio limitations](http://www.ibm.com/developerworks/library/wa-ioshtml5/) (see section `Unsupported events`) - there is some helpful workarounds for several limitations but not for our problem.
